### PR TITLE
WIP: Tests + small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,31 @@
+<?php
+
+$header = <<<'HEADER'
+This file is part of the Symfony package.
+
+(c) Fabien Potencier <fabien@symfony.com>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+HEADER;
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules(array(
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        '@PHPUnit48Migration:risky' => true,
+        'php_unit_no_expectation_annotation' => false, // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
+        'array_syntax' => array('syntax' => 'long'),
+        'protected_to_private' => false,
+        'header_comment' => [
+            'header' => $header,
+            'location' => 'after_open',
+        ],
+    ))
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: '7.1'
+
+before_install:
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
+  - composer global require --dev 'friendsofphp/php-cs-fixer:^2.11'
+  - export PATH="$PATH:$HOME/.composer/vendor/bin"
+
+install:
+  - composer update --no-progress --no-suggest --ansi
+
+script:
+  - php-cs-fixer fix --dry-run --diff --no-ansi
+  - vendor/bin/phpunit
+

--- a/Bundle/DependencyInjection/EnqueueBridgeExtension.php
+++ b/Bundle/DependencyInjection/EnqueueBridgeExtension.php
@@ -31,24 +31,24 @@ class EnqueueBridgeExtension extends Extension
             return;
         }
 
+        $contextManager = new Definition(AmqpContextManager::class, array(
+            new Reference('enqueue.transport.default.context'),
+        ));
+
         $receiverDefinition = new Definition(QueueInteropReceiver::class, array(
             new Reference('messenger.transport.default_decoder'),
-            new Definition(AmqpContextManager::class, array(
-                new Reference('enqueue.transport.default.context'),
-            )),
+            $contextManager,
+            $config['queue'],
             $config['topic'] ?: 'messages',
-            $config['queue'] ?: 'messages',
             $container->getParameter('kernel.debug'),
         ));
         $receiverDefinition->addTag('messenger.receiver');
 
         $senderDefinition = new Definition(QueueInteropSender::class, array(
             new Reference('messenger.transport.default_encoder'),
-            new Definition(AmqpContextManager::class, array(
-                new Reference('enqueue.transport.default.context'),
-            )),
+            $contextManager,
+            $config['queue'],
             $config['topic'] ?: 'messages',
-            $config['queue'] ?: 'messages',
             $container->getParameter('kernel.debug'),
             $config['deliveryDelay'],
             $config['timeToLive'],

--- a/Exception/RejectMessageException.php
+++ b/Exception/RejectMessageException.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Sam\Symfony\Bridge\EnqueueMessage;
+namespace Sam\Symfony\Bridge\EnqueueMessage\Exception;
 
-use Symfony\Component\Message\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 
 class RejectMessageException extends \LogicException implements ExceptionInterface
 {

--- a/Exception/RequeueMessageException.php
+++ b/Exception/RequeueMessageException.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Sam\Symfony\Bridge\EnqueueMessage;
+namespace Sam\Symfony\Bridge\EnqueueMessage\Exception;
 
-use Symfony\Component\Message\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 
 class RequeueMessageException extends \LogicException implements ExceptionInterface
 {

--- a/Exception/SendingMessageFailedException.php
+++ b/Exception/SendingMessageFailedException.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Sam\Symfony\Bridge\EnqueueMessage;
+namespace Sam\Symfony\Bridge\EnqueueMessage\Exception;
 
-use Symfony\Component\Message\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 
 class SendingMessageFailedException extends \LogicException implements ExceptionInterface
 {

--- a/MessageBusProcessor.php
+++ b/MessageBusProcessor.php
@@ -16,7 +16,9 @@ use Interop\Queue\PsrMessage;
 use Interop\Queue\PsrProcessor;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
+use Sam\Symfony\Bridge\EnqueueMessage\Exception\RejectMessageException;
+use Sam\Symfony\Bridge\EnqueueMessage\Exception\RequeueMessageException;
 
 /**
  * The processor could be used with any queue interop compatible consumer, for example Enqueue's QueueConsumer.

--- a/QueueInteropSender.php
+++ b/QueueInteropSender.php
@@ -14,6 +14,7 @@ namespace Sam\Symfony\Bridge\EnqueueMessage;
 use Interop\Queue\Exception;
 use Symfony\Component\Messenger\Transport\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
+use Sam\Symfony\Bridge\EnqueueMessage\Exception\SendingMessageFailedException;
 
 /**
  * Symfony Message sender to bridge Php-Enqueue producers.

--- a/Tests/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Bundle/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sam\Symfony\Bridge\EnqueueMessage\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+use Sam\Symfony\Bridge\EnqueueMessage\Bundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class ConfigurationTest extends TestCase
+{
+    private $configuration;
+    private $processor;
+
+    public function setUp()
+    {
+        $this->configuration = new Configuration();
+        $this->processor = new Processor();
+    }
+
+    public function testDefaultConfig()
+    {
+        $treeBuilder = $this->configuration->getConfigTreeBuilder();
+        $config = $this->processor->processConfiguration($this->configuration, array('enqueue_bridge' => array('queue' => 'test')));
+
+        $this->assertInstanceOf(ConfigurationInterface::class, $this->configuration);
+        $this->assertInstanceOf(TreeBuilder::class, $treeBuilder);
+
+        $this->assertEquals(array(
+            'enabled' => true,
+            'queue' => 'test',
+            'topic' => null,
+            'deliveryDelay' => null,
+            'timeToLive' => null,
+            'priority' => null,
+        ), $config);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testNeedQueueName()
+    {
+        $treeBuilder = $this->configuration->getConfigTreeBuilder();
+        $config = $this->processor->processConfiguration($this->configuration, array('enqueue_bridge' => array()));
+    }
+}

--- a/Tests/Bundle/DependencyInjection/EnqueueBridgeExtensionTest.php
+++ b/Tests/Bundle/DependencyInjection/EnqueueBridgeExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sam\Symfony\Bridge\EnqueueMessage\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sam\Symfony\Bridge\EnqueueMessage\Bundle\DependencyInjection\EnqueueBridgeExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class EnqueueBridgeExtensionTest extends TestCase
+{
+    private $extension;
+
+    public function setUp()
+    {
+        $this->extension = new EnqueueBridgeExtension();
+    }
+
+    public function testConstruct()
+    {
+        $this->extension = new EnqueueBridgeExtension();
+        $this->assertInstanceOf(ExtensionInterface::class, $this->extension);
+        $this->assertInstanceOf(ConfigurationExtensionInterface::class, $this->extension);
+    }
+
+    public function testLoad()
+    {
+        $config = array('enqueue_bridge' => array('queue' => 'message'));
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->getParameter('kernel.debug')->shouldBeCalled();
+        $containerBuilderProphecy->setDefinitions(Argument::that(function ($data) {
+            $this->assertSame(array_keys($data), array('enqueue_bridge.receiver', 'enqueue_bridge.sender'));
+
+            return true;
+        }))->shouldBeCalled();
+
+        $this->extension->load($config, $containerBuilderProphecy->reveal());
+    }
+}

--- a/Tests/MessageBusProcessorTest.php
+++ b/Tests/MessageBusProcessorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sam\Symfony\Bridge\EnqueueMessage\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
+use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Interop\Queue\PsrMessage;
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrProcessor;
+use Sam\Symfony\Bridge\EnqueueMessage\MessageBusProcessor;
+use Sam\Symfony\Bridge\EnqueueMessage\Exception\RejectMessageException;
+use Sam\Symfony\Bridge\EnqueueMessage\Exception\RequeueMessageException;
+use Prophecy\Argument;
+
+class MessageBusProcessorTest extends TestCase
+{
+    private function getTestMessage()
+    {
+        $messageProphecy = $this->prophesize(PsrMessage::class);
+        $messageProphecy->getBody()->shouldBeCalled()->willReturn('body');
+        $messageProphecy->getHeaders()->shouldBeCalled()->willReturn(array('header'));
+        $messageProphecy->getProperties()->shouldBeCalled()->willReturn('props');
+
+        return $messageProphecy->reveal();
+    }
+
+    public function testProcess()
+    {
+        $message = $this->getTestMessage();
+        $receivedMessage = new ReceivedMessage('test');
+        $contextProphecy = $this->prophesize(PsrContext::class);
+        $busProphecy = $this->prophesize(MessageBusInterface::class);
+        $busProphecy->dispatch($receivedMessage)->shouldBeCalled();
+        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy->decode(array(
+            'body' => 'body',
+            'headers' => array('header'),
+            'properties' => 'props',
+        ))->shouldBeCalled()->willReturn($receivedMessage);
+
+        $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
+        $this->assertSame(PsrProcessor::ACK, $messageBusProcessor->process($message, $contextProphecy->reveal()));
+    }
+
+    public function testProcessReject()
+    {
+        $message = $this->getTestMessage();
+        $receivedMessage = new ReceivedMessage('test');
+        $contextProphecy = $this->prophesize(PsrContext::class);
+        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($receivedMessage);
+        $busProphecy = $this->prophesize(MessageBusInterface::class);
+        $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new RejectMessageException());
+
+        $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
+        $this->assertSame(PsrProcessor::REJECT, $messageBusProcessor->process($message, $contextProphecy->reveal()));
+    }
+
+    public function testProcessRequeue()
+    {
+        $message = $this->getTestMessage();
+        $receivedMessage = new ReceivedMessage('test');
+        $contextProphecy = $this->prophesize(PsrContext::class);
+        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($receivedMessage);
+        $busProphecy = $this->prophesize(MessageBusInterface::class);
+        $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new RequeueMessageException());
+
+        $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
+        $this->assertSame(PsrProcessor::REQUEUE, $messageBusProcessor->process($message, $contextProphecy->reveal()));
+    }
+
+    public function testProcessRejectAnyException()
+    {
+        $message = $this->getTestMessage();
+        $receivedMessage = new ReceivedMessage('test');
+        $contextProphecy = $this->prophesize(PsrContext::class);
+        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($receivedMessage);
+        $busProphecy = $this->prophesize(MessageBusInterface::class);
+        $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new \InvalidArgumentException());
+
+        $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
+        $this->assertSame(PsrProcessor::REJECT, $messageBusProcessor->process($message, $contextProphecy->reveal()));
+    }
+}

--- a/Tests/QueueInteropSenderTest.php
+++ b/Tests/QueueInteropSenderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sam\Symfony\Bridge\EnqueueMessage\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Interop\Queue\PsrContext;
+use Interop\Queue\PsrProducer;
+use Interop\Queue\PsrDestination;
+use Interop\Queue\PsrMessage;
+use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
+use Sam\Symfony\Bridge\EnqueueMessage\ContextManager;
+use Sam\Symfony\Bridge\EnqueueMessage\QueueInteropSender;
+use Interop\Queue\Exception;
+
+class QueueInteropSenderTest extends TestCase
+{
+    public function testSendWithDebug()
+    {
+        $topic = 'topic';
+        $queue = 'queue';
+        $message = new \stdClass();
+        $message->foo = 'bar';
+
+        $psrMessageProphecy = $this->prophesize(PsrMessage::class);
+        $psrMessage = $psrMessageProphecy->reveal();
+        $topicProphecy = $this->prophesize(PsrDestination::class);
+        $psrTopic = $topicProphecy->reveal();
+
+        $producerProphecy = $this->prophesize(PsrProducer::class);
+        $producerProphecy->setDeliveryDelay(100)->shouldBeCalled();
+        $producerProphecy->setPriority(100)->shouldBeCalled();
+        $producerProphecy->setTimeToLive(100)->shouldBeCalled();
+        $producerProphecy->send($psrTopic, $psrMessage)->shouldBeCalled();
+
+        $psrContextProphecy = $this->prophesize(PsrContext::class);
+        $psrContextProphecy->createTopic($topic)->shouldBeCalled()->willReturn($psrTopic);
+        $psrContextProphecy->createProducer()->shouldBeCalled()->willReturn($producerProphecy->reveal());
+        $psrContextProphecy->createMessage('foo', array(), array())->shouldBeCalled()->willReturn($psrMessage);
+
+        $contextManagerProphecy = $this->prophesize(ContextManager::class);
+        $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
+        $contextManagerProphecy->ensureExists(array('topic' => $topic, 'queue' => $queue))->shouldBeCalled();
+
+        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy->encode($message)->shouldBeCalled()->willReturn(array('body' => 'foo'));
+
+        $queueInteropSender = new QueueInteropSender($encoderProphecy->reveal(), $contextManagerProphecy->reveal(), $topic, $queue, true, 100, 100, 100);
+        $queueInteropSender->send($message);
+    }
+
+    public function testSendWithoutDebug()
+    {
+        $topic = 'topic';
+        $queue = 'queue';
+        $message = new \stdClass();
+        $message->foo = 'bar';
+
+        $psrMessageProphecy = $this->prophesize(PsrMessage::class);
+        $psrMessage = $psrMessageProphecy->reveal();
+        $topicProphecy = $this->prophesize(PsrDestination::class);
+        $psrTopic = $topicProphecy->reveal();
+
+        $producerProphecy = $this->prophesize(PsrProducer::class);
+        $producerProphecy->send($psrTopic, $psrMessage)->shouldBeCalled();
+
+        $psrContextProphecy = $this->prophesize(PsrContext::class);
+        $psrContextProphecy->createTopic($topic)->shouldBeCalled()->willReturn($psrTopic);
+        $psrContextProphecy->createProducer()->shouldBeCalled()->willReturn($producerProphecy->reveal());
+        $psrContextProphecy->createMessage('foo', array(), array())->shouldBeCalled()->willReturn($psrMessage);
+
+        $contextManagerProphecy = $this->prophesize(ContextManager::class);
+        $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
+
+        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy->encode($message)->shouldBeCalled()->willReturn(array('body' => 'foo'));
+
+        $queueInteropSender = new QueueInteropSender($encoderProphecy->reveal(), $contextManagerProphecy->reveal(), $topic, $queue);
+        $queueInteropSender->send($message);
+    }
+
+    /**
+     * @expectedException \Sam\Symfony\Bridge\EnqueueMessage\Exception\SendingMessageFailedException
+     */
+    public function testThrow()
+    {
+        $topic = 'topic';
+        $queue = 'queue';
+        $message = new \stdClass();
+        $message->foo = 'bar';
+
+        $psrMessageProphecy = $this->prophesize(PsrMessage::class);
+        $psrMessage = $psrMessageProphecy->reveal();
+        $topicProphecy = $this->prophesize(PsrDestination::class);
+        $psrTopic = $topicProphecy->reveal();
+
+        $exception = new Exception();
+
+        $producerProphecy = $this->prophesize(PsrProducer::class);
+        $producerProphecy->send($psrTopic, $psrMessage)->shouldBeCalled()->willThrow($exception);
+
+        $psrContextProphecy = $this->prophesize(PsrContext::class);
+        $psrContextProphecy->createTopic($topic)->shouldBeCalled()->willReturn($psrTopic);
+        $psrContextProphecy->createProducer()->shouldBeCalled()->willReturn($producerProphecy->reveal());
+        $psrContextProphecy->createMessage('foo', array(), array())->shouldBeCalled()->willReturn($psrMessage);
+
+        $contextManagerProphecy = $this->prophesize(ContextManager::class);
+        $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
+        $contextManagerProphecy->recoverException($exception, array('topic' => $topic, 'queue' => $queue))->shouldBeCalled()->willReturn(false);
+
+        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy->encode($message)->shouldBeCalled()->willReturn(array('body' => 'foo'));
+
+        $queueInteropSender = new QueueInteropSender($encoderProphecy->reveal(), $contextManagerProphecy->reveal(), $topic, $queue);
+        $queueInteropSender->send($message);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,9 @@
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.1@dev",
+        "symfony/messenger": "^4.0@dev"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Enqueue Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
I'm not sure yet how I should test the infinite loop in the receiver but I'll find out :D.

I changed the order of the `queue` argument to keep same ordering between receiver and sender.
 
Also, should we introduce the `Enqueue\Consumption\QueueConsumer` so that we can use the Consumption Extensions?

For reference, currently if an error is thrown in the [decoding phase](https://github.com/sroze/enqueue-bridge/blob/master/QueueInteropReceiver.php#L71)  the exception is processed silently. 
Enqueue has a LoggingExtension (I assume for that purpose) and we may want to leverage it somehow.
Proposition by @sroze: 
> Though, I'd keep it simple by introducing `LoggerInterface` tbh...

Lmk your thoughts about this.

Can you enable travis? 